### PR TITLE
Lazy MappedObjectType field Type creation for memory optimization

### DIFF
--- a/src/Context/BaseFieldContext.php
+++ b/src/Context/BaseFieldContext.php
@@ -45,4 +45,15 @@ abstract class BaseFieldContext extends TypeContext
 		return $this->initializeObjects;
 	}
 
+	/**
+	 * @return static
+	 */
+	public function createClone(): self
+	{
+		$clone = parent::createClone();
+		$clone->options = clone $this->options;
+
+		return $clone;
+	}
+
 }

--- a/src/Context/TypeContext.php
+++ b/src/Context/TypeContext.php
@@ -7,6 +7,7 @@ use Orisai\ObjectMapper\Meta\MetaLoader;
 use Orisai\ObjectMapper\Meta\Runtime\RuntimeMeta;
 use Orisai\ObjectMapper\Rules\Rule;
 use Orisai\ObjectMapper\Rules\RuleManager;
+use function array_keys;
 
 class TypeContext
 {
@@ -14,6 +15,9 @@ class TypeContext
 	private MetaLoader $metaLoader;
 
 	private RuleManager $ruleManager;
+
+	/** @var array<class-string<MappedObject>, true> */
+	private array $processedClasses = [];
 
 	public function __construct(MetaLoader $metaLoader, RuleManager $ruleManager)
 	{
@@ -37,6 +41,33 @@ class TypeContext
 	public function getRule(string $rule): Rule
 	{
 		return $this->ruleManager->getRule($rule);
+	}
+
+	/**
+	 * @param class-string<MappedObject> $class
+	 */
+	public function withProcessedClass(string $class): self
+	{
+		$self = clone $this;
+		$self->processedClasses[$class] = true;
+
+		return $self;
+	}
+
+	/**
+	 * @return list<class-string<MappedObject>>
+	 */
+	public function getProcessedClasses(): array
+	{
+		return array_keys($this->processedClasses);
+	}
+
+	/**
+	 * @return static
+	 */
+	public function createClone(): self
+	{
+		return clone $this;
 	}
 
 }

--- a/src/Processing/Options.php
+++ b/src/Processing/Options.php
@@ -3,6 +3,8 @@
 namespace Orisai\ObjectMapper\Processing;
 
 use Orisai\Exceptions\Logic\InvalidState;
+use Orisai\ObjectMapper\MappedObject;
+use function array_keys;
 use function get_class;
 use function sprintf;
 
@@ -19,6 +21,9 @@ final class Options
 
 	/** @var array<class-string, object> */
 	private array $dynamicContexts = [];
+
+	/** @var array<class-string<MappedObject>, true> */
+	private array $processedClasses = [];
 
 	public function __construct()
 	{
@@ -108,6 +113,33 @@ final class Options
 		}
 
 		return $this->dynamicContexts[$class];
+	}
+
+	/**
+	 * @param class-string<MappedObject> $class
+	 */
+	public function withProcessedClass(string $class): self
+	{
+		$self = clone $this;
+		$self->processedClasses[$class] = true;
+
+		return $self;
+	}
+
+	/**
+	 * @return list<class-string<MappedObject>>
+	 */
+	public function getProcessedClasses(): array
+	{
+		return array_keys($this->processedClasses);
+	}
+
+	/**
+	 * @return static
+	 */
+	public function createClone(): self
+	{
+		return clone $this;
 	}
 
 }

--- a/src/Rules/AllOfRule.php
+++ b/src/Rules/AllOfRule.php
@@ -38,7 +38,7 @@ final class AllOfRule extends CompoundRule
 				$value = $nestedRule->processValue(
 					$value,
 					$nestedRuleArgs,
-					$context,
+					$context->createClone(),
 				);
 			} catch (ValueDoesNotMatch | InvalidData $exception) {
 				$exception->dropValue(); // May be mutated by rules

--- a/src/Rules/AnyOfRule.php
+++ b/src/Rules/AnyOfRule.php
@@ -37,7 +37,7 @@ final class AnyOfRule extends CompoundRule
 				$value = $nestedRule->processValue(
 					$value,
 					$nestedRuleArgs,
-					$context,
+					$context->createClone(),
 				);
 
 				$anyValidationSucceeded = true;

--- a/src/Rules/ArrayOfRule.php
+++ b/src/Rules/ArrayOfRule.php
@@ -122,7 +122,7 @@ final class ArrayOfRule extends MultiValueRule
 
 			if ($keyRule !== null && $keyArgs !== null) {
 				try {
-					$key = $keyRule->processValue($key, $keyArgs, $context);
+					$key = $keyRule->processValue($key, $keyArgs, $context->createClone());
 				} catch (ValueDoesNotMatch | InvalidData $exception) {
 					$keyException = $exception;
 				}
@@ -132,7 +132,7 @@ final class ArrayOfRule extends MultiValueRule
 				$value[$key] = $itemRule->processValue(
 					$item,
 					$itemArgs,
-					$context,
+					$context->createClone(),
 				);
 			} catch (ValueDoesNotMatch | InvalidData $exception) {
 				$itemException = $exception;
@@ -171,12 +171,12 @@ final class ArrayOfRule extends MultiValueRule
 		if ($keyMeta !== null) {
 			$keyRule = $context->getRule($keyMeta->getType());
 			$keyArgs = $keyMeta->getArgs();
-			$keyType = $keyRule->createType($keyArgs, $context);
+			$keyType = $keyRule->createType($keyArgs, $context->createClone());
 		}
 
 		$type = ArrayType::forArray(
 			$keyType ?? null,
-			$itemRule->createType($itemArgs, $context),
+			$itemRule->createType($itemArgs, $context->createClone()),
 		);
 
 		if ($args->minItems !== null) {

--- a/src/Rules/CompoundRule.php
+++ b/src/Rules/CompoundRule.php
@@ -66,7 +66,7 @@ abstract class CompoundRule implements Rule
 		foreach ($args->rules as $key => $nestedRuleMeta) {
 			$nestedRule = $context->getRule($nestedRuleMeta->getType());
 			$nestedRuleArgs = $nestedRuleMeta->getArgs();
-			$type->addSubtype($key, $nestedRule->createType($nestedRuleArgs, $context));
+			$type->addSubtype($key, $nestedRule->createType($nestedRuleArgs, $context->createClone()));
 		}
 
 		return $type;

--- a/src/Rules/ListOfRule.php
+++ b/src/Rules/ListOfRule.php
@@ -117,7 +117,7 @@ final class ListOfRule extends MultiValueRule
 				$value[$key] = $itemRule->processValue(
 					$item,
 					$itemArgs,
-					$context,
+					$context->createClone(),
 				);
 			} catch (ValueDoesNotMatch | InvalidData $exception) {
 				$type->addInvalidValue($key, $exception);
@@ -150,7 +150,7 @@ final class ListOfRule extends MultiValueRule
 
 		$type = ArrayType::forList(
 			$this->createKeyType(),
-			$itemRule->createType($itemArgs, $context),
+			$itemRule->createType($itemArgs, $context->createClone()),
 		);
 
 		if ($args->minItems !== null) {

--- a/src/Tester/TesterDependencies.php
+++ b/src/Tester/TesterDependencies.php
@@ -25,8 +25,6 @@ final class TesterDependencies
 
 	public Processor $processor;
 
-	public TypeContext $typeContext;
-
 	/**
 	 * @internal
 	 * @see ObjectMapperTester::buildDependencies()
@@ -42,12 +40,16 @@ final class TesterDependencies
 		$this->metaResolver = $metaResolver;
 		$this->ruleManager = $ruleManager;
 		$this->processor = $processor;
-		$this->typeContext = new TypeContext($metaLoader, $ruleManager);
 	}
 
 	public function createRuleArgsContext(ReflectionProperty $property): RuleArgsContext
 	{
 		return new RuleArgsContext($property, $this->ruleManager, $this->metaLoader, $this->metaResolver);
+	}
+
+	public function createTypeContext(): TypeContext
+	{
+		return new TypeContext($this->metaLoader, $this->ruleManager);
 	}
 
 	public function createFieldContext(
@@ -60,7 +62,7 @@ final class TesterDependencies
 			$this->metaLoader,
 			$this->ruleManager,
 			$this->processor,
-			$options ?? new Options(),
+			$options !== null ? clone $options : new Options(),
 			new MessageType('test'),
 			$defaultValueMeta ?? DefaultValueMeta::fromNothing(),
 			$initializeObjects,

--- a/src/Types/MappedObjectType.php
+++ b/src/Types/MappedObjectType.php
@@ -2,6 +2,7 @@
 
 namespace Orisai\ObjectMapper\Types;
 
+use Closure;
 use Orisai\ObjectMapper\Exception\WithTypeAndValue;
 use Orisai\ObjectMapper\MappedObject;
 
@@ -13,7 +14,7 @@ final class MappedObjectType implements Type
 	/** @var class-string<MappedObject> */
 	private string $class;
 
-	/** @var array<Type> */
+	/** @var array<Type|Closure(): Type> */
 	private array $fields = [];
 
 	/** @var array<WithTypeAndValue> */
@@ -39,9 +40,10 @@ final class MappedObjectType implements Type
 	}
 
 	/**
-	 * @param int|string $field
+	 * @param int|string           $field
+	 * @param Type|Closure(): Type $type
 	 */
-	public function addField($field, Type $type): void
+	public function addField($field, $type): void
 	{
 		$this->fields[$field] = $type;
 	}
@@ -60,7 +62,16 @@ final class MappedObjectType implements Type
 	 */
 	public function getFields(): array
 	{
-		return $this->fields;
+		$fields = [];
+		foreach ($this->fields as $field => $type) {
+			if ($type instanceof Closure) {
+				$type = $type();
+			}
+
+			$fields[$field] = $type;
+		}
+
+		return $fields;
 	}
 
 	/**

--- a/tests/Doubles/CircularAVO.php
+++ b/tests/Doubles/CircularAVO.php
@@ -2,7 +2,10 @@
 
 namespace Tests\Orisai\ObjectMapper\Doubles;
 
+use Orisai\ObjectMapper\Attributes\Expect\AnyOf;
 use Orisai\ObjectMapper\Attributes\Expect\MappedObjectValue;
+use Orisai\ObjectMapper\Attributes\Expect\NullValue;
+use Orisai\ObjectMapper\Attributes\Expect\StringValue;
 use Orisai\ObjectMapper\MappedObject;
 
 final class CircularAVO extends MappedObject
@@ -10,5 +13,13 @@ final class CircularAVO extends MappedObject
 
 	/** @MappedObjectValue(CircularBVO::class) */
 	public CircularBVO $b;
+
+	/**
+	 * @AnyOf({
+	 *     @StringValue(),
+	 *     @NullValue(),
+	 * })
+	 */
+	public ?string $stringOrNull = null;
 
 }

--- a/tests/Toolkit/ProcessingTestCase.php
+++ b/tests/Toolkit/ProcessingTestCase.php
@@ -28,8 +28,6 @@ abstract class ProcessingTestCase extends TestCase
 
 	protected Processor $processor;
 
-	protected TypeContext $typeContext;
-
 	protected function setUp(): void
 	{
 		$tester = new ObjectMapperTester();
@@ -38,7 +36,6 @@ abstract class ProcessingTestCase extends TestCase
 		$this->ruleManager = $deps->ruleManager;
 		$this->metaLoader = $deps->metaLoader;
 		$this->processor = $deps->processor;
-		$this->typeContext = $deps->typeContext;
 	}
 
 	protected function ruleArgsContext(?ReflectionProperty $property = null): RuleArgsContext
@@ -49,6 +46,11 @@ abstract class ProcessingTestCase extends TestCase
 		}
 
 		return $this->dependencies->createRuleArgsContext($property);
+	}
+
+	protected function createTypeContext(): TypeContext
+	{
+		return new TypeContext($this->metaLoader, $this->ruleManager);
 	}
 
 	protected function fieldContext(

--- a/tests/Unit/Processing/DefaultProcessorTest.php
+++ b/tests/Unit/Processing/DefaultProcessorTest.php
@@ -458,10 +458,7 @@ stringg: Field is unknown, did you mean `string`?',
 		self::assertSame(
 			<<<'MSG'
 selfOrNull: shape{
-	selfOrNull: shape{
-		selfOrNull: circular reference
-		another: string
-	}||null
+	selfOrNull: shape{}||null
 	another: string
 }||null
 MSG,
@@ -525,11 +522,10 @@ MSG,
 			<<<'MSG'
 b: shape{
 	c: shape{
-		as: list<int(continuous), shape{
-			b: circular reference
-		}>
+		as: list<int(continuous), shape{}>
 	}||null
 }
+stringOrNull: string||null
 MSG,
 			$this->formatter->printError($exception),
 		);

--- a/tests/Unit/Rules/AllOfRuleTest.php
+++ b/tests/Unit/Rules/AllOfRuleTest.php
@@ -130,7 +130,7 @@ final class AllOfRuleTest extends ProcessingTestCase
 			new RuleRuntimeMeta(AlwaysInvalidRule::class, new EmptyArgs()),
 		]);
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),

--- a/tests/Unit/Rules/AnyOfRuleTest.php
+++ b/tests/Unit/Rules/AnyOfRuleTest.php
@@ -126,7 +126,7 @@ final class AnyOfRuleTest extends ProcessingTestCase
 			new RuleRuntimeMeta(AlwaysInvalidRule::class, new EmptyArgs()),
 		]);
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),

--- a/tests/Unit/Rules/ArrayEnumRuleTest.php
+++ b/tests/Unit/Rules/ArrayEnumRuleTest.php
@@ -101,7 +101,7 @@ final class ArrayEnumRuleTest extends ProcessingTestCase
 	{
 		$args = new ArrayEnumArgs(['foo', 'bar']);
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),

--- a/tests/Unit/Rules/ArrayOfRuleTest.php
+++ b/tests/Unit/Rules/ArrayOfRuleTest.php
@@ -215,7 +215,7 @@ final class ArrayOfRuleTest extends ProcessingTestCase
 			new RuleRuntimeMeta(MixedRule::class, new EmptyArgs()),
 		);
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),
@@ -236,7 +236,7 @@ final class ArrayOfRuleTest extends ProcessingTestCase
 			100,
 		);
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),

--- a/tests/Unit/Rules/BackedEnumRuleTest.php
+++ b/tests/Unit/Rules/BackedEnumRuleTest.php
@@ -121,7 +121,7 @@ final class BackedEnumRuleTest extends ProcessingTestCase
 	{
 		$args = new BackedEnumArgs(ExampleStringEnum::class);
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),

--- a/tests/Unit/Rules/BoolRuleTest.php
+++ b/tests/Unit/Rules/BoolRuleTest.php
@@ -127,7 +127,7 @@ final class BoolRuleTest extends ProcessingTestCase
 	{
 		$args = new BoolArgs();
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),
@@ -142,7 +142,7 @@ final class BoolRuleTest extends ProcessingTestCase
 	{
 		$args = new BoolArgs(true);
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),

--- a/tests/Unit/Rules/DateTimeRuleTest.php
+++ b/tests/Unit/Rules/DateTimeRuleTest.php
@@ -155,7 +155,7 @@ final class DateTimeRuleTest extends ProcessingTestCase
 	{
 		$args = new DateTimeArgs();
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),
@@ -172,7 +172,7 @@ final class DateTimeRuleTest extends ProcessingTestCase
 	{
 		$args = new DateTimeArgs(DateTimeImmutable::class, DateTimeRule::FormatTimestamp);
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),
@@ -187,7 +187,7 @@ final class DateTimeRuleTest extends ProcessingTestCase
 	{
 		$args = new DateTimeArgs(DateTimeImmutable::class, DateTimeInterface::COOKIE);
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),

--- a/tests/Unit/Rules/FloatRuleTest.php
+++ b/tests/Unit/Rules/FloatRuleTest.php
@@ -200,7 +200,7 @@ final class FloatRuleTest extends ProcessingTestCase
 	{
 		$args = $this->rule->resolveArgs([], $this->ruleArgsContext());
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),
@@ -215,7 +215,7 @@ final class FloatRuleTest extends ProcessingTestCase
 	{
 		$args = new FloatArgs(10, 100, true, true);
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),

--- a/tests/Unit/Rules/InstanceRuleTest.php
+++ b/tests/Unit/Rules/InstanceRuleTest.php
@@ -97,7 +97,7 @@ final class InstanceRuleTest extends ProcessingTestCase
 	{
 		$args = new InstanceArgs(stdClass::class);
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),

--- a/tests/Unit/Rules/IntRuleTest.php
+++ b/tests/Unit/Rules/IntRuleTest.php
@@ -178,7 +178,7 @@ final class IntRuleTest extends ProcessingTestCase
 	{
 		$args = new IntArgs();
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),
@@ -193,7 +193,7 @@ final class IntRuleTest extends ProcessingTestCase
 	{
 		$args = new IntArgs(10, 100, true, true);
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),

--- a/tests/Unit/Rules/ListOfRuleTest.php
+++ b/tests/Unit/Rules/ListOfRuleTest.php
@@ -193,7 +193,7 @@ final class ListOfRuleTest extends ProcessingTestCase
 			new RuleRuntimeMeta(MixedRule::class, new EmptyArgs()),
 		);
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),
@@ -212,7 +212,7 @@ final class ListOfRuleTest extends ProcessingTestCase
 			100,
 		);
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),

--- a/tests/Unit/Rules/MappedObjectRuleTest.php
+++ b/tests/Unit/Rules/MappedObjectRuleTest.php
@@ -71,7 +71,7 @@ final class MappedObjectRuleTest extends ProcessingTestCase
 	{
 		$args = new MappedObjectArgs(DefaultsVO::class);
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),

--- a/tests/Unit/Rules/MixedRuleTest.php
+++ b/tests/Unit/Rules/MixedRuleTest.php
@@ -55,7 +55,7 @@ final class MixedRuleTest extends ProcessingTestCase
 	{
 		$args = new EmptyArgs();
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),

--- a/tests/Unit/Rules/NullRuleTest.php
+++ b/tests/Unit/Rules/NullRuleTest.php
@@ -105,7 +105,7 @@ final class NullRuleTest extends ProcessingTestCase
 	{
 		$args = new NullArgs();
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),
@@ -120,7 +120,7 @@ final class NullRuleTest extends ProcessingTestCase
 	{
 		$args = new NullArgs(true);
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),

--- a/tests/Unit/Rules/ObjectRuleTest.php
+++ b/tests/Unit/Rules/ObjectRuleTest.php
@@ -98,7 +98,7 @@ final class ObjectRuleTest extends ProcessingTestCase
 	{
 		$args = new EmptyArgs();
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),

--- a/tests/Unit/Rules/ScalarRuleTest.php
+++ b/tests/Unit/Rules/ScalarRuleTest.php
@@ -103,7 +103,7 @@ final class ScalarRuleTest extends ProcessingTestCase
 	{
 		$args = new EmptyArgs();
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),

--- a/tests/Unit/Rules/StringRuleTest.php
+++ b/tests/Unit/Rules/StringRuleTest.php
@@ -183,7 +183,7 @@ final class StringRuleTest extends ProcessingTestCase
 	{
 		$args = new StringArgs();
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),
@@ -198,7 +198,7 @@ final class StringRuleTest extends ProcessingTestCase
 	{
 		$args = new StringArgs('/[\s\S]/', true, 1, 10);
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),

--- a/tests/Unit/Rules/UrlRuleTest.php
+++ b/tests/Unit/Rules/UrlRuleTest.php
@@ -90,7 +90,7 @@ final class UrlRuleTest extends ProcessingTestCase
 	{
 		$args = new EmptyArgs();
 
-		$type = $this->rule->createType($args, $this->typeContext);
+		$type = $this->rule->createType($args, $this->createTypeContext());
 
 		self::assertEquals(
 			$this->rule->createType($args, $this->fieldContext()),

--- a/tests/Unit/Types/MappedObjectTypeTest.php
+++ b/tests/Unit/Types/MappedObjectTypeTest.php
@@ -108,4 +108,22 @@ final class MappedObjectTypeTest extends TestCase
 		);
 	}
 
+	public function testFieldFromClosure(): void
+	{
+		$type = new MappedObjectType(DefaultsVO::class);
+		$type->addField('field', static fn (): MessageType => new MessageType('test'));
+
+		$expectedFields = [
+			'field' => new MessageType('test'),
+		];
+
+		$fields = $type->getFields();
+		self::assertEquals($expectedFields, $fields);
+		self::assertNotSame($expectedFields, $fields);
+
+		$fields2 = $type->getFields();
+		self::assertEquals($fields, $fields2);
+		self::assertNotSame($fields, $fields2);
+	}
+
 }


### PR DESCRIPTION
Closes #43 

Printers and objects cloning should be still reviewed, but this is good enough for now